### PR TITLE
add documentation link in the error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: c
+
+os:
+  - linux
+#  - osx
+
+
+notifications:
+  email: false
+
+addons:
+  apt: # apt-get for linux
+    packages:
+    - gfortran
+    - make
+    - libarpack2-dev
+    - libnetcdf-dev
+    - libnetcdff-dev
+
+script:
+  - make
+  - cd SmallExample; ../dineof dineof.init
+
+#after_success:
+#  - bash <(curl -s https://codecov.io/bash)

--- a/SmallExample/Output/.gitignore
+++ b/SmallExample/Output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ssvd_lancz.F
+++ b/ssvd_lancz.F
@@ -476,7 +476,9 @@ c        %--------------------------%
 c
          print *, ' '
          print *, ' Error with _saupd, info = ', info
-         print *, ' Check documentation in _saupd '
+         print *, ' Check documentation in dsaupd '
+         print *, ' https://www.caam.rice.edu/software/' //
+     &              'ARPACK/UG/node136.html'
          print *, ' '
 c
       else 


### PR DESCRIPTION
It would be nice to the link to the documentation in the error like this:

```                                                                     
  Error with _saupd, info =           -3          
  Check documentation in _saupd                                      
```